### PR TITLE
Moved Token class to own file

### DIFF
--- a/coap-core/src/main/java/com/mbed/coap/client/ObservationHandlerImpl.java
+++ b/coap-core/src/main/java/com/mbed/coap/client/ObservationHandlerImpl.java
@@ -25,7 +25,7 @@ import com.mbed.coap.packet.MessageType;
 import com.mbed.coap.server.CoapExchange;
 import com.mbed.coap.server.ObservationHandler;
 import com.mbed.coap.utils.Callback;
-import java.util.Arrays;
+import com.mbed.coap.utils.Token;
 import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -120,38 +120,6 @@ class ObservationHandlerImpl implements ObservationHandler {
     @Override
     public boolean hasObservation(byte[] token) {
         return observationMap.containsKey(new Token(token));
-    }
-
-    static class Token {
-
-        private final byte[] tokenVal;
-
-        public Token(byte[] tokenVal) {
-            this.tokenVal = tokenVal;
-        }
-
-        @Override
-        public int hashCode() {
-            int hash = 5;
-            hash = 37 * hash + Arrays.hashCode(this.tokenVal);
-            return hash;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj == null) {
-                return false;
-            }
-            if (getClass() != obj.getClass()) {
-                return false;
-            }
-            final Token other = (Token) obj;
-            if (!Arrays.equals(this.tokenVal, other.tokenVal)) {
-                return false;
-            }
-            return true;
-        }
-
     }
 
     private static class ObservationListenerContainer {

--- a/coap-core/src/main/java/com/mbed/coap/utils/Token.java
+++ b/coap-core/src/main/java/com/mbed/coap/utils/Token.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2011-2017 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mbed.coap.utils;
+
+import java.util.Arrays;
+
+public class Token {
+
+    private final byte[] tokenVal;
+
+    public Token(byte[] tokenVal) {
+        this.tokenVal = tokenVal;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 37 * hash + Arrays.hashCode(this.tokenVal);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Token other = (Token) obj;
+        if (!Arrays.equals(this.tokenVal, other.tokenVal)) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/coap-core/src/test/java/com/mbed/coap/client/CoapClientTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/client/CoapClientTest.java
@@ -32,6 +32,7 @@ import com.mbed.coap.transport.BlockingCoapTransport;
 import com.mbed.coap.transport.TransportContext;
 import com.mbed.coap.utils.Callback;
 import com.mbed.coap.utils.FutureCallbackAdapter;
+import com.mbed.coap.utils.Token;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -244,7 +245,7 @@ public class CoapClientTest {
 
     @Test
     public void equalsAndHashTest() throws Exception {
-        EqualsVerifier.forClass(ObservationHandlerImpl.Token.class).suppress(Warning.NONFINAL_FIELDS).usingGetClass().verify();
+        EqualsVerifier.forClass(Token.class).suppress(Warning.NONFINAL_FIELDS).usingGetClass().verify();
     }
 
 


### PR DESCRIPTION
Moved Token to own file because it is needed when implementing ObservationHandler